### PR TITLE
Revert "Disable TLS 1.0 and TLS 1.1 and allow TLS 1.3"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@
 ### Changes
 
 * Always restart `nginx` container
-* Disable TLS 1.0 and TLS 1.1 and allow TLS 1.3
 
 ### v1.0.0 (2020-11-24)
 

--- a/buguette-https.conf
+++ b/buguette-https.conf
@@ -29,7 +29,6 @@ server {
   ssl_certificate_key /etc/letsencrypt/live/buguette.teamlab.info/privkey.pem;
   include /etc/letsencrypt/options-ssl-nginx.conf;
   ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
-  ssl_protocols TLSv1.2 TLSv1.3;
 
   location / {
       try_files $uri $uri/ /index.html;


### PR DESCRIPTION
Reverts ONLYOFFICE-QA/buguette#98

This change just duplicate default settings

This should be disable by editing `/etc/letsencrypt/options-ssl-nginx.conf` file on host