### PR TITLE
Increase build memory limits

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 ### STAGE 1: Build ###
 FROM node:12.14-alpine AS build
+
+ENV NODE_OPTIONS=--max-old-space-size=1024
 WORKDIR /buguette
 COPY package.json ./
 COPY package-lock.json ./


### PR DESCRIPTION
Without it build on 1gb machine with 4gb swap will fail with:
```
buguette-build_1   | Compiling @angular/material/button-toggle : es2015 as esm2015
⠧ Generating browser application bundles (phase: building)...
buguette-build_1   | <--- Last few GCs --->
buguette-build_1   |
buguette-build_1   | [18:0x5556bea688a0]   128059 ms: Mark-sweep 485.1 (498.6) -> 483.9 (500.9) MB, 1012.1 / 0.1 ms  (average mu = 0.233, current mu = 0.177) allocation failure scavenge might not succeed
buguette-build_1   | [18:0x5556bea688a0]   129126 ms: Mark-sweep 486.8 (500.9) -> 485.4 (499.5) MB, 997.2 / 0.1 ms  (average mu = 0.155, current mu = 0.065) allocation failure scavenge might not succeed
buguette-build_1   |
buguette-build_1   |
buguette-build_1   | <--- JS stacktrace --->
buguette-build_1   |
buguette-build_1   | ==== JS stack trace =========================================
buguette-build_1   |
buguette-build_1   |     0: ExitFrame [pc: 0x5556bc7e8ef9]
buguette-build_1   |     1: StubFrame [pc: 0x5556bc78ef31]
buguette-build_1   | Security context: 0x27cda59008a1 <JSObject>
buguette-build_1   |     2: slice [0x27cda5911159](this=0x00a6f518e369 <JSArray[3]>,1)
buguette-build_1   |     3: getUsedName [0xd0f455bfee9] [/buguette/node_modules/webpack/lib/ExportsInfo.js:681] [bytecode=0x12d94ce6c4a1 offset=260](this=0x21946a0c8281 <ExportsInfo map = 0x22f30d40cdc1>,0x00a6f518e369 <JSArray[3]>,0x2e16740d9ea9 <String[#7]: runtime>)
buguette-build_1   |     4: ...
buguette-build_1   |
buguette-build_1   | FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory
buguette-build_1   |
buguette-build_1   | Writing Node.js report to file: report.20210513.084905.18.0.001.json
buguette-build_1   | Node.js report completed
buguette_buguette-build_1 exited with code 0
```