### PR TITLE
Increase dependabot limit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
   directory: "/"
   schedule:
     interval: daily
-  open-pull-requests-limit: 10
+  open-pull-requests-limit: 20
 - package-ecosystem: docker
   directory: "/"
   schedule:


### PR DESCRIPTION
Sometimes then angular is updated only angular PR's are around 10
And if there is any other updates - they are missed