### PR TITLE
Add `/.angular/cache` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ speed-measure-plugin*.json
 .history/*
 
 # misc
+/.angular/cache
 /.sass-cache
 /connect.lock
 /coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Add `Android Projects App` product
 * Add `DocumentServer Installation` product
 * Add `yamllint` in CI
+* Add `/.angular/cache` to `.gitignore`
 
 ### Fixes
 


### PR DESCRIPTION
Those are by default in gitignore of new project
since angular v13